### PR TITLE
Workaround invalid assert

### DIFF
--- a/org.gnunet.Messenger.json
+++ b/org.gnunet.Messenger.json
@@ -95,7 +95,13 @@
 	},
 	{
 	  "name": "libgnunetchat",
-	  "buildsystem": "meson",
+	  "buildsystem": "simple",
+	  "build-commands": [
+		"sed -i '47,49d' src/gnunet_chat_lib.c",
+		"meson setup --prefix /app --buildtype release custom-build",
+		"meson compile -C custom-build",
+		"meson install -C custom-build"
+	  ],
 	  "sources": [
 	    {
 		  "type": "archive",


### PR DESCRIPTION
Currently the assert noticing the version mismatch between messenger service protocol and the chat API in libgnunetchat crashes the application. This issue will be resolved in upcoming releases. But for now removing the assert fixes the crash.