### PR TITLE
Fix pipewire connection issue

### DIFF
--- a/org.gnunet.Messenger.json
+++ b/org.gnunet.Messenger.json
@@ -18,7 +18,7 @@
         "--filesystem=xdg-public-share:ro",
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-templates:ro",
-        "--device=all"
+		"--filesystem=xdg-run/pipewire-0"
     ],
     "cleanup": [
         "/include",

--- a/org.gnunet.Messenger.json
+++ b/org.gnunet.Messenger.json
@@ -18,7 +18,7 @@
         "--filesystem=xdg-public-share:ro",
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-templates:ro",
-		"--filesystem=xdg-run/pipewire-0"
+        "--filesystem=xdg-run/pipewire-0"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
The connection issue caused an unhandled crash. Next releases will properly handle such cases.