### PR TITLE
Fix url of qrencode to build

### DIFF
--- a/org.gnunet.Messenger.json
+++ b/org.gnunet.Messenger.json
@@ -127,13 +127,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz",
-                    "sha512": "209bb656ae3f391b03c7b3ceb03e34f7320b0105babf48b619e7a299528b8828449e0e7696f0b5db0d99170a81709d0518e34835229a748701e7df784e58a9ce",
+                    "url": "https://github.com/fukuchi/libqrencode/archive/refs/tags/v4.1.1.tar.gz",
+                    "sha512": "584106e7bcaaa1ef2efe63d653daad38d4ff436eb4b185a1db3c747169c1ffa74149c3b1329bb0b8ae007903db0a7034aabf135cc196d91a37b5c61348154a65",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/fukuchi/libqrencode/releases/latest",
                         "version-query": ".tag_name | sub(\"^v\"; \"\")",
-                        "url-query": ".tag_name | sub(\"^v\"; \"https://fukuchi.org/works/qrencode/qrencode-\") | sub(\"$\"; \".tar.gz\")"
+                        "url-query": ".tag_name | sub(\"^v\"; \"https://github.com/fukuchi/libqrencode/archive/refs/tags/v\") | sub(\"$\"; \".tar.gz\")"
                     }
                 }
             ]


### PR DESCRIPTION
Use the release archive of qrencode on Github.