### PR TITLE
Use GStreamer modules from runtime (closing #84)

### DIFF
--- a/org.gnunet.Messenger.json
+++ b/org.gnunet.Messenger.json
@@ -70,16 +70,23 @@
         {
             "name": "libsodium",
             "buildsystem": "autotools",
+			"build-options": {
+				"arch": {
+					"aarch64": {
+						"cflags": "-march=armv8-a+crypto+aes"
+					}
+				}
+			},
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.libsodium.org/libsodium/releases/libsodium-1.0.21-stable.tar.gz",
-                    "sha512": "20fd50c752a18accb06814496e53ae7ce71aa7f4fe43a3e7f27e0dc818afa5ba3274016f7bc4b166e133b61a4758710b7a84c97d907701e3a5abbde7fd529f77",
+                    "url": "https://github.com/jedisct1/libsodium/releases/download/1.0.20-RELEASE/libsodium-1.0.20.tar.gz",
+                    "sha512": "7ea165f3c1b1609790e30a16348b9dfdc5731302da00c07c65e125c8ab115c75419a5631876973600f8a4b560ca2c8267001770b68f2eb3eebc9ba095d312702",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/jedisct1/libsodium/releases/latest",
                         "version-query": ".tag_name | sub(\"-RELEASE$\"; \"\")",
-                        "url-template": "https://download.libsodium.org/libsodium/releases/libsodium-$version-stable.tar.gz",
+                        "url-query": ".assets[] | select(.name==\"libsodium-\" + $version + \".tar.gz\") | .browser_download_url",
                         "is-important": true
                     }
                 }


### PR DESCRIPTION
This closes issue #84 by simply dropping the explicit build of GStreamer dependencies and using it from the GNOME runtime.

Additionally this PR reverts the change from point release of libsodium to stable release since the stable release is not reliable for reproducible builds. Unfortunately this enforces a rollback to libsodium 1.0.20 because the release of 1.0.21 breaks aarch64 builds (see [here](https://github.com/jedisct1/libsodium/issues/1509)).